### PR TITLE
feat: add core util functions and tests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -45,3 +45,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          submodules: 'true'
+
+      # I think this version is a bit older and
+      # doesn't contain the JUnit support, but should
+      # suffice for the time being.
+      - name: Install bats
+        shell: bash
+        run: sudo apt install bats
+
+      - name: Run unit tests
+        shell: bash
+        run: bats -r tests/unit

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -38,6 +38,7 @@ jobs:
         uses: ludeeus/action-shellcheck@1.0.0
         with:
           additional_files: '*.bats'
+          check_together: 'yes'
 
   tests:
     name: tests

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "tests/helper_libs/bats-support"]
-	path = test_helper_libs/bats-support
-	url = https://github.com/bats-core/bats-support
+  path = test_helper_libs/bats-support
+  url = https://github.com/bats-core/bats-support
 [submodule "tests/helper_libs/bats-assert"]
-	path = test_helper_libs/bats-assert
-	url = https://github.com/bats-core/bats-assert
+  path = test_helper_libs/bats-assert
+  url = https://github.com/bats-core/bats-assert

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "tests/helper_libs/bats-support"]
-	path = tests/helper_libs/bats-support
+	path = test_helper_libs/bats-support
 	url = https://github.com/bats-core/bats-support
 [submodule "tests/helper_libs/bats-assert"]
-	path = tests/helper_libs/bats-assert
+	path = test_helper_libs/bats-assert
 	url = https://github.com/bats-core/bats-assert

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,6 @@
+[submodule "tests/helper_libs/bats-support"]
+	path = tests/helper_libs/bats-support
+	url = https://github.com/bats-core/bats-support
+[submodule "tests/helper_libs/bats-assert"]
+	path = tests/helper_libs/bats-assert
+	url = https://github.com/bats-core/bats-assert

--- a/.vscode/cSpell.json
+++ b/.vscode/cSpell.json
@@ -3,8 +3,10 @@
   "language": "en",
   "words": [
     "cygwin",
+    "distro",
     "dotfiles",
     "mingw",
+    "mkdir",
     "readonly",
     "shellcheck",
     "swellaby",

--- a/.vscode/cSpell.json
+++ b/.vscode/cSpell.json
@@ -6,11 +6,13 @@
     "cygwin",
     "distro",
     "dotfiles",
+    "pacman",
     "mingw",
     "mkdir",
     "readonly",
     "rhel",
     "shellcheck",
+    "subcommand",
     "swellaby",
     "tmpdir"
   ],

--- a/.vscode/cSpell.json
+++ b/.vscode/cSpell.json
@@ -9,6 +9,7 @@
     "pacman",
     "mingw",
     "mkdir",
+    "nyancat",
     "readonly",
     "rhel",
     "shellcheck",

--- a/.vscode/cSpell.json
+++ b/.vscode/cSpell.json
@@ -2,7 +2,13 @@
   "version": "0.1",
   "language": "en",
   "words": [
-    "dotfiles"
+    "cygwin",
+    "dotfiles",
+    "mingw",
+    "readonly",
+    "shellcheck",
+    "swellaby",
+    "tmpdir"
   ],
   "flagWords": [
 

--- a/.vscode/cSpell.json
+++ b/.vscode/cSpell.json
@@ -5,7 +5,9 @@
     "centos",
     "cygwin",
     "distro",
+    "dfpn",
     "dotfiles",
+    "ffpn",
     "pacman",
     "mingw",
     "mkdir",
@@ -13,6 +15,8 @@
     "readonly",
     "rhel",
     "shellcheck",
+    "shfmt",
+    "snapcraft",
     "subcommand",
     "swellaby",
     "tmpdir"

--- a/.vscode/cSpell.json
+++ b/.vscode/cSpell.json
@@ -2,12 +2,14 @@
   "version": "0.1",
   "language": "en",
   "words": [
+    "centos",
     "cygwin",
     "distro",
     "dotfiles",
     "mingw",
     "mkdir",
     "readonly",
+    "rhel",
     "shellcheck",
     "swellaby",
     "tmpdir"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "files.exclude": {
     "**/.git": true,
-    "tests/helper_libs/**": true,
+    "test_helper_libs/**": true,
   },
   "cSpell.enabled": true,
   "cSpell.ignorePaths": [

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,8 @@
 {
+  "files.exclude": {
+    "**/.git": true,
+    "tests/helper_libs/**": true,
+  },
   "cSpell.enabled": true,
   "cSpell.ignorePaths": [
     "**/.git/**",

--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
-echo "todo..."
+source src/packages/utils.sh
+
+install -n nyancat

--- a/install.sh
+++ b/install.sh
@@ -2,4 +2,4 @@
 
 source src/packages/utils.sh
 
-install -n nyancat
+install_package -n nyancat -p

--- a/src/packages/utils.sh
+++ b/src/packages/utils.sh
@@ -10,8 +10,27 @@ declare -x OPERATING_SYSTEM=""
 # of most major distributions, as well as anything running systemd
 declare -x LINUX_DISTRO_OS_IDENTIFICATION_FILE="/etc/os-release"
 
+LINUX_DISTRO=""
+readonly UBUNTU_DISTRO="ubuntu"
+readonly DEBIAN_DISTRO="debian"
+readonly FEDORA_DISTRO="fedora"
+readonly RHEL_DISTRO="rhel"
+readonly CENTOS_DISTRO="centos"
+
+declare -x LINUX_DISTRO_FAMILY=""
+readonly DEBIAN_DISTRO_FAMILY=${DEBIAN_DISTRO}
+readonly FEDORA_DISTRO_FAMILY=${FEDORA_DISTRO}
+
 function error() {
   echo "[swellaby_dotfiles]: $*" >&2
+}
+
+function set_debian_variables() {
+  LINUX_DISTRO_FAMILY=${DEBIAN_DISTRO_FAMILY}
+}
+
+function set_fedora_variables() {
+  LINUX_DISTRO_FAMILY=${FEDORA_DISTRO_FAMILY}
 }
 
 function set_linux_variables() {
@@ -21,7 +40,19 @@ function set_linux_variables() {
     exit 1
   fi
 
-  return 0
+  local id
+  id=$(grep -oP '(?<=^ID=).+' ${LINUX_DISTRO_OS_IDENTIFICATION_FILE} | tr -d '"')
+  LINUX_DISTRO=$id
+  echo "Detected Linux distro: ${LINUX_DISTRO}"
+
+  case $id in
+    ${DEBIAN_DISTRO}) set_debian_variables ;;
+    ${UBUNTU_DISTRO}) set_debian_variables ;;
+    ${FEDORA_DISTRO}) set_fedora_variables ;;
+    ${RHEL_DISTRO}) set_fedora_variables ;;
+    ${CENTOS_DISTRO}) set_fedora_variables ;;
+    *) error "Unsupported distro ${LINUX_DISTRO}" && exit 1 ;;
+  esac
 }
 
 function set_macos_variables() {
@@ -42,6 +73,8 @@ function initialize() {
   readonly unix_name
   readonly OPERATING_SYSTEM
   readonly LINUX_DISTRO_OS_IDENTIFICATION_FILE
+  readonly LINUX_DISTRO
+  readonly LINUX_DISTRO_FAMILY
 }
 
 # Don't auto initialize during when sourced for running tests

--- a/src/packages/utils.sh
+++ b/src/packages/utils.sh
@@ -141,7 +141,7 @@ function install_snap() {
     return 1
   fi
 
-  ${INSTALLER_PREFIX} snap install ${snap_prefix} ${snap_name}
+  "${INSTALLER_PREFIX}" snap install "${snap_prefix}" "${snap_name}"
 }
 
 function install_package() {
@@ -165,7 +165,7 @@ function install_package() {
     shift
   done
 
-  if [ -z ${package_name} ]; then
+  if [ -z "${package_name}" ]; then
     error "No package name provided to 'install_package'"
     return 1
   fi
@@ -221,6 +221,7 @@ function install() {
       error "Snap install preferred but Snap not available. This is a bug!"
     else
       install_snap -n "${snap_name}"
+      # shellcheck disable=SC2181
       if [ $? -eq 0 ]; then
         return 0
       else

--- a/src/packages/utils.sh
+++ b/src/packages/utils.sh
@@ -25,6 +25,10 @@ function error() {
   echo "[swellaby_dotfiles]: $*" >&2
 }
 
+function info() {
+  echo "[swellaby_dotfiles]: $*" >&1
+}
+
 function set_debian_variables() {
   LINUX_DISTRO_FAMILY=${DEBIAN_DISTRO_FAMILY}
 }
@@ -43,7 +47,7 @@ function set_linux_variables() {
   local id
   id=$(grep -oP '(?<=^ID=).+' ${LINUX_DISTRO_OS_IDENTIFICATION_FILE} | tr -d '"')
   LINUX_DISTRO=$id
-  echo "Detected Linux distro: ${LINUX_DISTRO}"
+  info "Detected Linux distro: ${LINUX_DISTRO}"
 
   case $id in
     "${DEBIAN_DISTRO}") set_debian_variables ;;

--- a/src/packages/utils.sh
+++ b/src/packages/utils.sh
@@ -44,7 +44,7 @@ readonly MACOS_INSTALL_SUBCOMMAND="install"
 INSTALLER_PREFIX=""
 INSTALLER_SUFFIX=""
 INSTALL_SUBCOMMAND=""
-INSTALL_COMMAND=""
+declare -x INSTALL_COMMAND=""
 
 function error() {
   echo "[swellaby_dotfiles]: $*" >&2

--- a/src/packages/utils.sh
+++ b/src/packages/utils.sh
@@ -136,7 +136,7 @@ function install_snap() {
     shift
   done
 
-  if [ -z ${snap_name} ]; then
+  if [ -z "${snap_name}" ]; then
     error "No snap name provided to 'install_snap'"
     return 1
   fi
@@ -170,7 +170,7 @@ function install_package() {
     return 1
   fi
 
-  ${INSTALL_COMMAND} ${package_prefix} ${package_name}
+  "${INSTALL_COMMAND}" "${package_prefix}" "${package_name}"s
 }
 
 function install() {
@@ -231,8 +231,7 @@ function install() {
     fi
   fi
 
-  if [ -z ${package_name} ]; then
-    echo "# no package name?" >&3
+  if [ -z "${package_name}" ]; then
     error "No package name provided for installation"
     return 1
   fi

--- a/src/packages/utils.sh
+++ b/src/packages/utils.sh
@@ -13,6 +13,7 @@ declare -x OPERATING_SYSTEM=""
 declare -x LINUX_DISTRO_OS_IDENTIFICATION_FILE="/etc/os-release"
 
 LINUX_DISTRO=""
+SNAP_AVAILABLE=true
 readonly UBUNTU_DISTRO="ubuntu"
 readonly DEBIAN_DISTRO="debian"
 readonly FEDORA_DISTRO="fedora"
@@ -85,12 +86,25 @@ function set_linux_variables() {
   fi
 
   case $id in
-    "${DEBIAN_DISTRO}") set_debian_variables ;;
-    "${UBUNTU_DISTRO}") set_debian_variables ;;
-    "${FEDORA_DISTRO}") set_fedora_variables ;;
-    "${RHEL_DISTRO}") set_fedora_variables ;;
-    "${CENTOS_DISTRO}") set_fedora_variables ;;
-    *) error "Unsupported distro: '${LINUX_DISTRO}'" && exit 1 ;;
+    "${DEBIAN_DISTRO}")
+      set_debian_variables
+      ;;
+    "${UBUNTU_DISTRO}")
+      set_debian_variables
+      ;;
+    "${FEDORA_DISTRO}")
+      set_fedora_variables
+      ;;
+    "${RHEL_DISTRO}")
+      set_fedora_variables
+      ;;
+    "${CENTOS_DISTRO}")
+      set_fedora_variables
+      ;;
+    *)
+      error "Unsupported distro: '${LINUX_DISTRO}'"
+      exit 1
+      ;;
   esac
 }
 
@@ -98,6 +112,131 @@ function set_macos_variables() {
   OPERATING_SYSTEM=${MAC_OS}
   PACKAGE_MANAGER=${MACOS_PACKAGE_MANAGER}
   INSTALL_SUBCOMMAND=${MACOS_INSTALL_SUBCOMMAND}
+  SNAP_AVAILABLE=false
+}
+
+function install_snap() {
+  local snap_name
+  local snap_prefix
+  while [[ "$#" -gt 0 ]]; do
+    case $1 in
+      -n|--snap-name)
+        snap_name="${2}"
+        shift
+        ;;
+      -p|--snap-prefix)
+        snap_prefix="${2}"
+        shift
+        ;;
+      *)
+        error "Invalid 'install_snap' arg: '${1}'. This is a bug!"
+        exit 1
+        ;;
+    esac
+    shift
+  done
+
+  if [ -z ${snap_name} ]; then
+    error "No snap name provided to 'install_snap'"
+    return 1
+  fi
+
+  ${INSTALLER_PREFIX} snap install ${snap_prefix} ${snap_name}
+}
+
+function install_package() {
+  local package_name
+  local package_prefix
+  while [[ "$#" -gt 0 ]]; do
+    case $1 in
+      -n|--package-name)
+        package_name="${2}"
+        shift
+        ;;
+      -p|--package-prefix)
+        package_prefix="${2}"
+        shift
+        ;;
+      *)
+        error "Invalid 'install_package' arg. This is a bug!"
+        exit 1
+        ;;
+    esac
+    shift
+  done
+
+  if [ -z ${package_name} ]; then
+    error "No package name provided to 'install_package'"
+    return 1
+  fi
+
+  ${INSTALL_COMMAND} ${package_prefix} ${package_name}
+}
+
+function install() {
+  local prefer_snap
+  local package_name
+  local package_prefix
+  local snap_name
+  local snap_prefix
+
+  if [ $# -eq 0 ]; then
+    error "No args passed to 'install' but at a minimum a snap or package name must be provided. This is a bug!"
+    exit 1
+  fi
+
+  prefer_snap=false
+
+  while [[ "$#" -gt 0 ]]; do
+    case $1 in
+      -pfs|--prefer-snap)
+        prefer_snap=true
+        ;;
+      -n|--package-name)
+        package_name="${2}"
+        shift
+        ;;
+      -pp|--package-prefix)
+        package_prefix="${2}"
+        shift
+        ;;
+      -s|--snap-name)
+        snap_name="${2}"
+        shift
+        ;;
+      -sp|--snap-prefix)
+        snap_prefix="${2}"
+        shift
+        ;;
+      *)
+        error "Invalid 'install' arg: '${1}'. This is a bug!"
+        exit 1
+        ;;
+    esac
+    shift
+  done
+
+  if [ "${prefer_snap}" == true ]; then
+    if [ ${SNAP_AVAILABLE} != true ]; then
+      error "Snap install preferred but Snap not available. This is a bug!"
+    else
+      install_snap -n "${snap_name}"
+      if [ $? -eq 0 ]; then
+        return 0
+      else
+        error "Attempted but failed to install Snap: '${snap_name}'"
+        error "Falling back to package manager"
+      fi
+    fi
+  fi
+
+  if [ -z ${package_name} ]; then
+    echo "# no package name?" >&3
+    error "No package name provided for installation"
+    return 1
+  fi
+
+  install_package -n "${package_name}"
 }
 
 function initialize() {
@@ -122,10 +261,16 @@ function initialize() {
   readonly PACKAGE_MANAGER
   readonly INSTALL_COMMAND
   readonly INSTALL_SUBCOMMAND
+  readonly SNAP_AVAILABLE
 }
 
 # Don't auto initialize during when sourced for running tests
 # https://github.com/bats-core/bats-core#special-variables
 if [[ -z ${BATS_TEST_NAME} ]]; then
   initialize
+  unset set_debian_variables
+  unset set_fedora_variables
+  unset set_linux_variables
+  unset set_macos_variables
+  unset initialize
 fi

--- a/src/packages/utils.sh
+++ b/src/packages/utils.sh
@@ -1,0 +1,38 @@
+# shellcheck shell=bash
+
+readonly MAC_OS="macos"
+readonly LINUX_OS="linux"
+declare -x OPERATING_SYSTEM=""
+
+unix_name=$(uname)
+
+function error() {
+  echo "[swellaby_dotfiles]: $*" >&2
+}
+
+function set_linux_variables() {
+  OPERATING_SYSTEM=$LINUX_OS
+  return 0
+}
+
+function set_macos_variables() {
+  OPERATING_SYSTEM=${MAC_OS}
+  return 0
+}
+
+function initialize() {
+  if [ "${unix_name}" == "Darwin" ]; then
+    set_macos_variables
+  elif [ "${unix_name}" == "Linux" ]; then
+    set_linux_variables
+  else
+    error "Unsupported OS. Are you on Windows using Git Bash or Cygwin?"
+    exit 1
+  fi
+}
+
+# Don't auto initialize during when sourced for running tests
+# https://github.com/bats-core/bats-core#special-variables
+if [[ -z ${BATS_TEST_NAME} ]]; then
+  initialize
+fi

--- a/src/packages/utils.sh
+++ b/src/packages/utils.sh
@@ -1,10 +1,14 @@
 # shellcheck shell=bash
 
+unix_name=$(uname)
+
 readonly MAC_OS="macos"
 readonly LINUX_OS="linux"
 declare -x OPERATING_SYSTEM=""
 
-unix_name=$(uname)
+# This file should be present on the vast majority of modern versions
+# of most major distributions, as well as anything running systemd
+declare -x LINUX_DISTRO_OS_IDENTIFICATION_FILE="/etc/os-release"
 
 function error() {
   echo "[swellaby_dotfiles]: $*" >&2
@@ -12,6 +16,11 @@ function error() {
 
 function set_linux_variables() {
   OPERATING_SYSTEM=$LINUX_OS
+  if [ ! -f ${LINUX_DISTRO_OS_IDENTIFICATION_FILE} ]; then
+    error "Detected Linux OS but did not find '${LINUX_DISTRO_OS_IDENTIFICATION_FILE}' file"
+    exit 1
+  fi
+
   return 0
 }
 
@@ -30,8 +39,9 @@ function initialize() {
     exit 1
   fi
 
-  readonly OPERATING_SYSTEM
   readonly unix_name
+  readonly OPERATING_SYSTEM
+  readonly LINUX_DISTRO_OS_IDENTIFICATION_FILE
 }
 
 # Don't auto initialize during when sourced for running tests

--- a/src/packages/utils.sh
+++ b/src/packages/utils.sh
@@ -21,6 +21,29 @@ declare -x LINUX_DISTRO_FAMILY=""
 readonly DEBIAN_DISTRO_FAMILY=${DEBIAN_DISTRO}
 readonly FEDORA_DISTRO_FAMILY=${FEDORA_DISTRO}
 
+# Configure package managers.
+# Maybe one day these can be added...
+# FreeBSD = pkg
+# SUSE = zypper
+# Arch = pacman
+# Gentoo = portage
+PACKAGE_MANAGER=""
+readonly DEBIAN_PACKAGE_MANAGER="apt"
+readonly DEBIAN_INSTALL_SUBCOMMAND="install"
+readonly DEBIAN_INSTALLER_SUFFIX="-y --no-install-recommends"
+
+readonly FEDORA_PACKAGE_MANAGER="dnf"
+readonly FEDORA_INSTALL_SUBCOMMAND="install"
+readonly FEDORA_INSTALLER_SUFFIX="-y"
+
+readonly MACOS_PACKAGE_MANAGER="brew"
+readonly MACOS_INSTALL_SUBCOMMAND="install"
+
+INSTALLER_PREFIX=""
+INSTALLER_SUFFIX=""
+INSTALL_SUBCOMMAND=""
+INSTALL_COMMAND=""
+
 function error() {
   echo "[swellaby_dotfiles]: $*" >&2
 }
@@ -31,10 +54,16 @@ function info() {
 
 function set_debian_variables() {
   LINUX_DISTRO_FAMILY=${DEBIAN_DISTRO_FAMILY}
+  PACKAGE_MANAGER=${DEBIAN_PACKAGE_MANAGER}
+  INSTALLER_SUFFIX=${DEBIAN_INSTALLER_SUFFIX}
+  INSTALL_SUBCOMMAND=${DEBIAN_INSTALL_SUBCOMMAND}
 }
 
 function set_fedora_variables() {
   LINUX_DISTRO_FAMILY=${FEDORA_DISTRO_FAMILY}
+  PACKAGE_MANAGER=${FEDORA_PACKAGE_MANAGER}
+  INSTALLER_SUFFIX=${FEDORA_INSTALLER_SUFFIX}
+  INSTALL_SUBCOMMAND=${FEDORA_INSTALL_SUBCOMMAND}
 }
 
 function set_linux_variables() {
@@ -47,7 +76,7 @@ function set_linux_variables() {
   local id
   id=$(grep -oP '(?<=^ID=).+' ${LINUX_DISTRO_OS_IDENTIFICATION_FILE} | tr -d '"')
   LINUX_DISTRO=$id
-  info "Detected Linux distro: ${LINUX_DISTRO}"
+  info "Detected Linux distro: '${LINUX_DISTRO}'"
 
   case $id in
     "${DEBIAN_DISTRO}") set_debian_variables ;;
@@ -55,13 +84,14 @@ function set_linux_variables() {
     "${FEDORA_DISTRO}") set_fedora_variables ;;
     "${RHEL_DISTRO}") set_fedora_variables ;;
     "${CENTOS_DISTRO}") set_fedora_variables ;;
-    *) error "Unsupported distro ${LINUX_DISTRO}" && exit 1 ;;
+    *) error "Unsupported distro: '${LINUX_DISTRO}'" && exit 1 ;;
   esac
 }
 
 function set_macos_variables() {
   OPERATING_SYSTEM=${MAC_OS}
-  return 0
+  PACKAGE_MANAGER=${MACOS_PACKAGE_MANAGER}
+  INSTALL_SUBCOMMAND=${MACOS_INSTALL_SUBCOMMAND}
 }
 
 function initialize() {

--- a/src/packages/utils.sh
+++ b/src/packages/utils.sh
@@ -29,6 +29,9 @@ function initialize() {
     error "Unsupported OS. Are you on Windows using Git Bash or Cygwin?"
     exit 1
   fi
+
+  readonly OPERATING_SYSTEM
+  readonly unix_name
 }
 
 # Don't auto initialize during when sourced for running tests

--- a/src/packages/utils.sh
+++ b/src/packages/utils.sh
@@ -120,11 +120,11 @@ function install_snap() {
   local snap_prefix
   while [[ "$#" -gt 0 ]]; do
     case $1 in
-      -n|--snap-name)
+      -n | --snap-name)
         snap_name="${2}"
         shift
         ;;
-      -p|--snap-prefix)
+      -p | --snap-prefix)
         snap_prefix="${2}"
         shift
         ;;
@@ -149,11 +149,11 @@ function install_package() {
   local package_prefix
   while [[ "$#" -gt 0 ]]; do
     case $1 in
-      -n|--package-name)
+      -n | --package-name)
         package_name="${2}"
         shift
         ;;
-      -p|--package-prefix)
+      -p | --package-prefix)
         package_prefix="${2}"
         shift
         ;;
@@ -189,22 +189,22 @@ function install() {
 
   while [[ "$#" -gt 0 ]]; do
     case $1 in
-      -pfs|--prefer-snap)
+      -pfs | --prefer-snap)
         prefer_snap=true
         ;;
-      -n|--package-name)
+      -n | --package-name)
         package_name="${2}"
         shift
         ;;
-      -pp|--package-prefix)
+      -pp | --package-prefix)
         package_prefix="${2}"
         shift
         ;;
-      -s|--snap-name)
+      -s | --snap-name)
         snap_name="${2}"
         shift
         ;;
-      -sp|--snap-prefix)
+      -sp | --snap-prefix)
         snap_prefix="${2}"
         shift
         ;;

--- a/src/packages/utils.sh
+++ b/src/packages/utils.sh
@@ -1,5 +1,7 @@
 # shellcheck shell=bash
 
+# Enable easier mocking in tests
+USER_ID=${UID}
 unix_name=$(uname)
 
 readonly MAC_OS="macos"
@@ -104,11 +106,18 @@ function initialize() {
     exit 1
   fi
 
+  INSTALL_COMMAND="${INSTALLER_PREFIX} ${PACKAGE_MANAGER} ${INSTALL_SUBCOMMAND} ${INSTALLER_SUFFIX}"
+
   readonly unix_name
   readonly OPERATING_SYSTEM
   readonly LINUX_DISTRO_OS_IDENTIFICATION_FILE
   readonly LINUX_DISTRO
   readonly LINUX_DISTRO_FAMILY
+  readonly INSTALLER_PREFIX
+  readonly INSTALLER_SUFFIX
+  readonly PACKAGE_MANAGER
+  readonly INSTALL_COMMAND
+  readonly INSTALL_SUBCOMMAND
 }
 
 # Don't auto initialize during when sourced for running tests

--- a/src/packages/utils.sh
+++ b/src/packages/utils.sh
@@ -138,7 +138,7 @@ function install_snap() {
   done
 
   if [ -z "${snap_name}" ]; then
-    error "No snap name provided to 'install_snap'"
+    error "No snap name provided to 'install_snap'. This is a bug!"
     return 1
   fi
 

--- a/src/packages/utils.sh
+++ b/src/packages/utils.sh
@@ -80,6 +80,10 @@ function set_linux_variables() {
   LINUX_DISTRO=$id
   info "Detected Linux distro: '${LINUX_DISTRO}'"
 
+  if [ ${USER_ID} -ne 0 ]; then
+    INSTALLER_PREFIX="sudo"
+  fi
+
   case $id in
     "${DEBIAN_DISTRO}") set_debian_variables ;;
     "${UBUNTU_DISTRO}") set_debian_variables ;;

--- a/src/packages/utils.sh
+++ b/src/packages/utils.sh
@@ -46,11 +46,11 @@ function set_linux_variables() {
   echo "Detected Linux distro: ${LINUX_DISTRO}"
 
   case $id in
-    ${DEBIAN_DISTRO}) set_debian_variables ;;
-    ${UBUNTU_DISTRO}) set_debian_variables ;;
-    ${FEDORA_DISTRO}) set_fedora_variables ;;
-    ${RHEL_DISTRO}) set_fedora_variables ;;
-    ${CENTOS_DISTRO}) set_fedora_variables ;;
+    "${DEBIAN_DISTRO}") set_debian_variables ;;
+    "${UBUNTU_DISTRO}") set_debian_variables ;;
+    "${FEDORA_DISTRO}") set_fedora_variables ;;
+    "${RHEL_DISTRO}") set_fedora_variables ;;
+    "${CENTOS_DISTRO}") set_fedora_variables ;;
     *) error "Unsupported distro ${LINUX_DISTRO}" && exit 1 ;;
   esac
 }

--- a/src/packages/utils.sh
+++ b/src/packages/utils.sh
@@ -142,7 +142,8 @@ function install_snap() {
     return 1
   fi
 
-  "${INSTALLER_PREFIX}" snap install "${snap_prefix}" "${snap_name}"
+  # shellcheck disable=SC2086
+  ${INSTALLER_PREFIX} snap install ${snap_prefix} "${snap_name}"
 }
 
 function install_package() {
@@ -160,7 +161,7 @@ function install_package() {
         shift
         ;;
       *)
-        error "Invalid 'install_package' arg. This is a bug!"
+        error "Invalid 'install_package' arg: '${1}'. This is a bug!"
         exit 1
         ;;
     esac
@@ -168,11 +169,12 @@ function install_package() {
   done
 
   if [ -z "${package_name}" ]; then
-    error "No package name provided to 'install_package'"
+    error "No package name provided to 'install_package'. This is a bug!"
     return 1
   fi
 
-  "${INSTALL_COMMAND}" "${package_prefix}" "${package_name}"s
+  # shellcheck disable=SC2086
+  ${INSTALL_COMMAND} ${package_prefix} ${package_name}
 }
 
 function install() {

--- a/src/packages/utils.sh
+++ b/src/packages/utils.sh
@@ -240,6 +240,7 @@ function install() {
     if [ ${SNAP_AVAILABLE} != true ]; then
       error "Snap install preferred but Snap not available. This is a bug!"
     else
+      # shellcheck disable=SC2046
       install_snap -n "${snap_name}"$([ -z "${snap_prefix}" ] && echo "" || echo " -p ${snap_prefix}")
       # shellcheck disable=SC2181
       if [ $? -eq 0 ]; then
@@ -262,6 +263,7 @@ function install() {
       # it's most likely a case of "not yet implemented" that shouldn't necessarily
       # crash the whole script though.
     else
+      # shellcheck disable=SC2046
       install_package -n "${package}"$([ -z "${prefix}" ] && echo "" || echo " -p ${prefix}")
     fi
   }
@@ -277,6 +279,7 @@ function install() {
       # it's most likely a case of "not yet implemented" that shouldn't necessarily
       # crash the whole script though.
     else
+      # shellcheck disable=SC2046
       install_package -n "${mac_package_name}"$([ -z "${mac_package_prefix}" ] && echo "" || echo " -p ${mac_package_prefix}")
     fi
   else

--- a/tests/test_helpers.sh
+++ b/tests/test_helpers.sh
@@ -6,6 +6,9 @@
 readonly TMP_FILE_DIR=${BATS_TMPDIR}/bats/swellaby-dotfiles
 readonly OS_RELEASE_TMP_FILE=${TMP_FILE_DIR}/os-release
 readonly ERROR_MESSAGE_PREFIX="[swellaby_dotfiles]: "
+readonly MOCKED_INSTALL_SNAP_CALL_ARGS_PREFIX="mock_install_snap: "
+readonly MOCKED_INSTALL_PACKAGE_CALL_ARGS_PREFIX="mock_install_package: "
+readonly MOCKED_DEFAULT_RETURN_CODE=0
 
 function setup_os_release_file() {
   mkdir -p "${TMP_FILE_DIR}"
@@ -33,4 +36,46 @@ function mock_grep_distro() {
   }
 
   declare -f grep
+}
+
+function mock_install_snap() {
+  _install_snap_return_code=${1:-$MOCKED_DEFAULT_RETURN_CODE}
+
+  function install_snap() {
+    echo "${MOCKED_INSTALL_SNAP_CALL_ARGS_PREFIX}$*"
+    # shellcheck disable=SC2086
+    return ${_install_snap_return_code}
+  }
+
+  declare -f install_snap
+}
+
+function mock_install_package() {
+  _install_package_return_code=${1:-$MOCKED_DEFAULT_RETURN_CODE}
+
+  function install_package() {
+    echo "${MOCKED_INSTALL_PACKAGE_CALL_ARGS_PREFIX}$*"
+    # shellcheck disable=SC2086
+    return ${_install_package_return_code}
+  }
+
+  declare -f install_package
+}
+
+function assert_mock_install_snap_called_with() {
+  local output
+  local exp_args
+  output="${1}"
+  exp_args="${2}"
+
+  assert_equal "${output}" "${MOCKED_INSTALL_SNAP_CALL_ARGS_PREFIX}${exp_args}"
+}
+
+function assert_mock_install_package_called_with() {
+  local output
+  local exp_args
+  output="${1}"
+  exp_args="${2}"
+
+  assert_equal "${output}" "${MOCKED_INSTALL_PACKAGE_CALL_ARGS_PREFIX}${exp_args}"
 }

--- a/tests/test_helpers.sh
+++ b/tests/test_helpers.sh
@@ -1,0 +1,3 @@
+# shellcheck shell=bash
+
+readonly TMP_FILE_DIR=${BATS_TMPDIR}/bats/swellaby-dotfiles

--- a/tests/test_helpers.sh
+++ b/tests/test_helpers.sh
@@ -16,7 +16,7 @@ function teardown_os_release_file() {
   rm -f "${OS_RELEASE_TMP_FILE}" || true
 }
 
-function assert_error_output() {
+function assert_output_contains() {
   local output
   local exp_details
   output=$1

--- a/tests/test_helpers.sh
+++ b/tests/test_helpers.sh
@@ -24,3 +24,13 @@ function assert_error_output() {
 
   assert_equal "${output}" "${ERROR_MESSAGE_PREFIX}${exp_details}"
 }
+
+function mock_grep_distro() {
+  _distro=$1
+
+  function grep() {
+    echo "${_distro}"
+  }
+
+  declare -f grep
+}

--- a/tests/test_helpers.sh
+++ b/tests/test_helpers.sh
@@ -8,12 +8,12 @@ readonly OS_RELEASE_TMP_FILE=${TMP_FILE_DIR}/os-release
 readonly ERROR_MESSAGE_PREFIX="[swellaby_dotfiles]: "
 
 function setup_os_release_file() {
-  mkdir -p ${TMP_FILE_DIR}
-  touch ${OS_RELEASE_TMP_FILE}
+  mkdir -p "${TMP_FILE_DIR}"
+  touch "${OS_RELEASE_TMP_FILE}"
 }
 
 function teardown_os_release_file() {
-  rm -f ${OS_RELEASE_TMP_FILE} || true
+  rm -f "${OS_RELEASE_TMP_FILE}" || true
 }
 
 function assert_error_output() {

--- a/tests/test_helpers.sh
+++ b/tests/test_helpers.sh
@@ -1,3 +1,26 @@
 # shellcheck shell=bash
 
+# load "../../../test_helper_libs/bats-support/load"
+# load "../../../test_helper_libs/bats-assert/load"
+
 readonly TMP_FILE_DIR=${BATS_TMPDIR}/bats/swellaby-dotfiles
+readonly OS_RELEASE_TMP_FILE=${TMP_FILE_DIR}/os-release
+readonly ERROR_MESSAGE_PREFIX="[swellaby_dotfiles]: "
+
+function setup_os_release_file() {
+  mkdir -p ${TMP_FILE_DIR}
+  touch ${OS_RELEASE_TMP_FILE}
+}
+
+function teardown_os_release_file() {
+  rm -f ${OS_RELEASE_TMP_FILE} || true
+}
+
+function assert_error_output() {
+  local output
+  local exp_details
+  output=$1
+  exp_details=$2
+
+  assert_equal "${output}" "${ERROR_MESSAGE_PREFIX}${exp_details}"
+}

--- a/tests/unit/packages/utils.bats
+++ b/tests/unit/packages/utils.bats
@@ -22,7 +22,7 @@ function assert_fedora_variables() {
   distro=${1}
   result=${2}
 
-  assert_equal ${result} 0
+  assert_equal "${result}" 0
   assert_equal "${OPERATING_SYSTEM}" "${LINUX_OS}"
   assert_equal "${LINUX_DISTRO}" "${distro}"
   assert_equal "${LINUX_DISTRO_FAMILY}" "${FEDORA_DISTRO_FAMILY}"
@@ -37,7 +37,7 @@ function assert_debian_variables() {
   distro=${1}
   result=${2}
 
-  assert_equal ${result} 0
+  assert_equal "${result}" 0
   assert_equal "${OPERATING_SYSTEM}" "${LINUX_OS}"
   assert_equal "${LINUX_DISTRO}" "${distro}"
   assert_equal "${LINUX_DISTRO_FAMILY}" "${DEBIAN_DISTRO_FAMILY}"

--- a/tests/unit/packages/utils.bats
+++ b/tests/unit/packages/utils.bats
@@ -16,6 +16,30 @@ function teardown() {
   teardown_os_release_file
 }
 
+function assert_fedora_variables() {
+  local distro
+  local result
+  distro=${1}
+  result=${2}
+
+  assert_equal ${result} 0
+  assert_equal "${OPERATING_SYSTEM}" "${LINUX_OS}"
+  assert_equal "${LINUX_DISTRO}" "${distro}"
+  assert_equal "${LINUX_DISTRO_FAMILY}" "${FEDORA_DISTRO_FAMILY}"
+}
+
+function assert_debian_variables() {
+  local distro
+  local result
+  distro=${1}
+  result=${2}
+
+  assert_equal ${result} 0
+  assert_equal "${OPERATING_SYSTEM}" "${LINUX_OS}"
+  assert_equal "${LINUX_DISTRO}" "${distro}"
+  assert_equal "${LINUX_DISTRO_FAMILY}" "${DEBIAN_DISTRO_FAMILY}"
+}
+
 @test "error function writes correct contents to stderr" {
   exp="oh nose :("
   run error "${exp}"
@@ -53,8 +77,33 @@ function teardown() {
   mock_grep_distro ${CENTOS_DISTRO}
   initialize
 
-  assert_equal $? 0
-  assert_equal "${OPERATING_SYSTEM}" "${LINUX_OS}"
-  assert_equal "${LINUX_DISTRO}" "${CENTOS_DISTRO}"
-  assert_equal "${LINUX_DISTRO_FAMILY}" "${FEDORA_DISTRO_FAMILY}"
+  assert_fedora_variables ${CENTOS_DISTRO} $?
+}
+
+@test "rhel bootstrapped correctly" {
+  mock_grep_distro ${RHEL_DISTRO}
+  initialize
+
+  assert_fedora_variables ${RHEL_DISTRO} $?
+}
+
+@test "fedora bootstrapped correctly" {
+  mock_grep_distro ${FEDORA_DISTRO}
+  initialize
+
+  assert_fedora_variables ${FEDORA_DISTRO} $?
+}
+
+@test "ubuntu bootstrapped correctly" {
+  mock_grep_distro ${UBUNTU_DISTRO}
+  initialize
+
+  assert_debian_variables ${UBUNTU_DISTRO} $?
+}
+
+@test "debian bootstrapped correctly" {
+  mock_grep_distro ${DEBIAN_DISTRO}
+  initialize
+
+  assert_debian_variables ${DEBIAN_DISTRO} $?
 }

--- a/tests/unit/packages/utils.bats
+++ b/tests/unit/packages/utils.bats
@@ -48,3 +48,13 @@ function teardown() {
   assert_equal "$status" 1
   assert_error_output "${output}" "${exp_err}"
 }
+
+@test "centos bootstrapped correctly" {
+  mock_grep_distro ${CENTOS_DISTRO}
+  initialize
+
+  assert_equal $? 0
+  assert_equal "${OPERATING_SYSTEM}" "${LINUX_OS}"
+  assert_equal "${LINUX_DISTRO}" "${CENTOS_DISTRO}"
+  assert_equal "${LINUX_DISTRO_FAMILY}" "${FEDORA_DISTRO_FAMILY}"
+}

--- a/tests/unit/packages/utils.bats
+++ b/tests/unit/packages/utils.bats
@@ -3,18 +3,24 @@
 load "../../../test_helper_libs/bats-support/load"
 load "../../../test_helper_libs/bats-assert/load"
 
+# shellcheck source=tests/test_helpers.sh
 source "${BATS_TEST_DIRNAME}/../../test_helpers.sh"
 
 function setup() {
   # shellcheck source=src/packages/utils.sh
   source "${BATS_TEST_DIRNAME}"/../../../src/packages/utils.sh
+  setup_os_release_file
+}
+
+function teardown() {
+  teardown_os_release_file
 }
 
 @test "error function writes correct contents to stderr" {
   exp="oh nose :("
   run error ${exp}
   assert_equal "$status" 0
-  assert_equal "${output}" "[swellaby_dotfiles]: ${exp}"
+  assert_error_output "${output}" "${exp}"
 }
 
 @test "mac bootstrapped correctly" {
@@ -32,4 +38,14 @@ function setup() {
   run initialize
   assert_equal "$status" 1
   assert_equal "${output}" "${exp_err}"
+}
+
+@test "linux install errors correctly without identification file" {
+  rm $OS_RELEASE_TMP_FILE
+  declare -x LINUX_DISTRO_OS_IDENTIFICATION_FILE=$OS_RELEASE_TMP_FILE
+  exp_err="Detected Linux OS but did not find '${OS_RELEASE_TMP_FILE}' file"
+
+  run initialize
+  assert_equal "$status" 1
+  assert_error_output "${output}" "${exp_err}"
 }

--- a/tests/unit/packages/utils.bats
+++ b/tests/unit/packages/utils.bats
@@ -3,9 +3,18 @@
 load "../../../test_helper_libs/bats-support/load"
 load "../../../test_helper_libs/bats-assert/load"
 
+source "${BATS_TEST_DIRNAME}/../../test_helpers.sh"
+
 function setup() {
   # shellcheck source=src/packages/utils.sh
   source "${BATS_TEST_DIRNAME}"/../../../src/packages/utils.sh
+}
+
+@test "error function writes correct contents to stderr" {
+  exp="oh nose :("
+  run error ${exp}
+  assert_equal "$status" 0
+  assert_equal "${output}" "[swellaby_dotfiles]: ${exp}"
 }
 
 @test "mac bootstrapped correctly" {
@@ -13,4 +22,14 @@ function setup() {
   initialize
   assert_equal $? 0
   assert_equal "${OPERATING_SYSTEM}" "${MAC_OS}"
+}
+
+@test "windows errors correctly" {
+  declare -x unix_name="MINGW"
+
+  exp_err="[swellaby_dotfiles]: Unsupported OS. Are you on Windows using Git Bash or Cygwin?"
+
+  run initialize
+  assert_equal "$status" 1
+  assert_equal "${output}" "${exp_err}"
 }

--- a/tests/unit/packages/utils.bats
+++ b/tests/unit/packages/utils.bats
@@ -26,6 +26,7 @@ function assert_fedora_variables() {
   assert_equal "${OPERATING_SYSTEM}" "${LINUX_OS}"
   assert_equal "${LINUX_DISTRO}" "${distro}"
   assert_equal "${LINUX_DISTRO_FAMILY}" "${FEDORA_DISTRO_FAMILY}"
+  assert_equal "${PACKAGE_MANAGER}" "${FEDORA_PACKAGE_MANAGER}"
   assert_equal "${INSTALL_SUBCOMMAND}" "${FEDORA_INSTALL_SUBCOMMAND}"
   assert_equal "${INSTALLER_SUFFIX}" "${FEDORA_INSTALLER_SUFFIX}"
 }
@@ -40,6 +41,7 @@ function assert_debian_variables() {
   assert_equal "${OPERATING_SYSTEM}" "${LINUX_OS}"
   assert_equal "${LINUX_DISTRO}" "${distro}"
   assert_equal "${LINUX_DISTRO_FAMILY}" "${DEBIAN_DISTRO_FAMILY}"
+  assert_equal "${PACKAGE_MANAGER}" "${DEBIAN_PACKAGE_MANAGER}"
   assert_equal "${INSTALL_SUBCOMMAND}" "${DEBIAN_INSTALL_SUBCOMMAND}"
   assert_equal "${INSTALLER_SUFFIX}" "${DEBIAN_INSTALLER_SUFFIX}"
 }
@@ -65,6 +67,9 @@ function assert_debian_variables() {
   assert_equal "${OPERATING_SYSTEM}" "${MAC_OS}"
   assert_equal "${PACKAGE_MANAGER}" "${MACOS_PACKAGE_MANAGER}"
   assert_equal "${INSTALL_SUBCOMMAND}" "${MACOS_INSTALL_SUBCOMMAND}"
+  assert_equal "${INSTALLER_PREFIX}" ""
+  assert_equal "${INSTALLER_SUFFIX}" ""
+  assert_equal "${INSTALL_COMMAND}" " ${MACOS_PACKAGE_MANAGER} ${MACOS_INSTALL_SUBCOMMAND} "
 }
 
 @test "windows errors correctly" {
@@ -78,47 +83,46 @@ function assert_debian_variables() {
 
 @test "linux install errors correctly without identification file" {
   rm "${OS_RELEASE_TMP_FILE}"
-  declare -x LINUX_DISTRO_OS_IDENTIFICATION_FILE=$OS_RELEASE_TMP_FILE
   exp_err="Detected Linux OS but did not find '${OS_RELEASE_TMP_FILE}' file"
 
-  run initialize
+  LINUX_DISTRO_OS_IDENTIFICATION_FILE="${OS_RELEASE_TMP_FILE}" run initialize
   assert_equal "$status" 1
   assert_output_contains "${output}" "${exp_err}"
 }
 
 @test "centos bootstrapped correctly" {
-  mock_grep_distro ${CENTOS_DISTRO}
+  mock_grep_distro "${CENTOS_DISTRO}"
   initialize
 
-  assert_fedora_variables ${CENTOS_DISTRO} $?
+  assert_fedora_variables "${CENTOS_DISTRO}" $?
 }
 
 @test "rhel bootstrapped correctly" {
-  mock_grep_distro ${RHEL_DISTRO}
+  mock_grep_distro "${RHEL_DISTRO}"
   initialize
 
-  assert_fedora_variables ${RHEL_DISTRO} $?
+  assert_fedora_variables "${RHEL_DISTRO}" $?
 }
 
 @test "fedora bootstrapped correctly" {
-  mock_grep_distro ${FEDORA_DISTRO}
+  mock_grep_distro "${FEDORA_DISTRO}"
   initialize
 
-  assert_fedora_variables ${FEDORA_DISTRO} $?
+  assert_fedora_variables "${FEDORA_DISTRO}" $?
 }
 
 @test "ubuntu bootstrapped correctly" {
-  mock_grep_distro ${UBUNTU_DISTRO}
+  mock_grep_distro "${UBUNTU_DISTRO}"
   initialize
 
-  assert_debian_variables ${UBUNTU_DISTRO} $?
+  assert_debian_variables "${UBUNTU_DISTRO}" $?
 }
 
 @test "debian bootstrapped correctly" {
-  mock_grep_distro ${DEBIAN_DISTRO}
+  mock_grep_distro "${DEBIAN_DISTRO}"
   initialize
 
-  assert_debian_variables ${DEBIAN_DISTRO} $?
+  assert_debian_variables "${DEBIAN_DISTRO}" $?
 }
 
 @test "unsupported distro errors correctly" {
@@ -128,4 +132,42 @@ function assert_debian_variables() {
   assert_equal "$status" 1
   assert_output_contains "${lines[0]}" "Detected Linux distro: '${distro}'"
   assert_output_contains "${lines[1]}" "Unsupported distro: '${distro}'"
+}
+
+@test "linux install prefix set correctly with root" {
+  mock_grep_distro "${DEBIAN_DISTRO}"
+  USER_ID=0 initialize
+
+  assert_equal "${INSTALLER_PREFIX}" ""
+  assert_equal "${INSTALL_COMMAND}" " ${DEBIAN_PACKAGE_MANAGER} ${DEBIAN_INSTALL_SUBCOMMAND} ${DEBIAN_INSTALLER_SUFFIX}"
+}
+
+@test "linux install prefix set correctly without root" {
+  mock_grep_distro "${FEDORA_DISTRO}"
+  USER_ID=1 initialize
+  assert_equal "${INSTALLER_PREFIX}" "sudo"
+  assert_equal "${INSTALL_COMMAND}" "sudo ${FEDORA_PACKAGE_MANAGER} ${FEDORA_INSTALL_SUBCOMMAND} ${FEDORA_INSTALLER_SUFFIX}"
+}
+
+@test "global defaults set correctly" {
+  assert_equal "${USER_ID}" "${UID}"
+  assert_equal "${unix_name}" "$(uname)"
+  assert_equal "${MAC_OS}" "macos"
+  assert_equal "${LINUX_OS}" "linux"
+  assert_equal "${UBUNTU_DISTRO}" "ubuntu"
+  assert_equal "${DEBIAN_DISTRO}" "debian"
+  assert_equal "${FEDORA_DISTRO}" "fedora"
+  assert_equal "${RHEL_DISTRO}" "rhel"
+  assert_equal "${CENTOS_DISTRO}" "centos"
+  assert_equal "${DEBIAN_DISTRO_FAMILY}" "debian"
+  assert_equal "${FEDORA_DISTRO_FAMILY}" "fedora"
+
+  assert_equal "${DEBIAN_PACKAGE_MANAGER}" "apt"
+  assert_equal "${DEBIAN_INSTALL_SUBCOMMAND}" "install"
+  assert_equal "${DEBIAN_INSTALLER_SUFFIX}" "-y --no-install-recommends"
+  assert_equal "${FEDORA_PACKAGE_MANAGER}" "dnf"
+  assert_equal "${FEDORA_INSTALL_SUBCOMMAND}" "install"
+  assert_equal "${FEDORA_INSTALLER_SUFFIX}" "-y"
+  assert_equal "${MACOS_PACKAGE_MANAGER}" "brew"
+  assert_equal "${MACOS_INSTALL_SUBCOMMAND}" "install"
 }

--- a/tests/unit/packages/utils.bats
+++ b/tests/unit/packages/utils.bats
@@ -4,11 +4,12 @@ load "../../../test_helper_libs/bats-support/load"
 load "../../../test_helper_libs/bats-assert/load"
 
 function setup() {
-  source ${BATS_TEST_DIRNAME}/../../../src/packages/utils.sh
+  # shellcheck source=src/packages/utils.sh
+  source "${BATS_TEST_DIRNAME}"/../../../src/packages/utils.sh
 }
 
 @test "mac bootstrapped correctly" {
-  unix_name="Darwin"
+  declare -x unix_name="Darwin"
   initialize
   assert_equal $? 0
   assert_equal "${OPERATING_SYSTEM}" "${MAC_OS}"

--- a/tests/unit/packages/utils.bats
+++ b/tests/unit/packages/utils.bats
@@ -44,7 +44,14 @@ function assert_debian_variables() {
   exp="oh nose :("
   run error "${exp}"
   assert_equal "$status" 0
-  assert_error_output "${output}" "${exp}"
+  assert_output_contains "${output}" "${exp}"
+}
+
+@test "info function writes correct contents to stdout" {
+  exp="something or other"
+  run info "${exp}"
+  assert_equal "$status" 0
+  assert_output_contains "${output}" "${exp}"
 }
 
 @test "mac bootstrapped correctly" {
@@ -70,7 +77,7 @@ function assert_debian_variables() {
 
   run initialize
   assert_equal "$status" 1
-  assert_error_output "${output}" "${exp_err}"
+  assert_output_contains "${output}" "${exp_err}"
 }
 
 @test "centos bootstrapped correctly" {
@@ -106,4 +113,13 @@ function assert_debian_variables() {
   initialize
 
   assert_debian_variables ${DEBIAN_DISTRO} $?
+}
+
+@test "unsupported distro errors correctly" {
+  distro="super new kinda fake distro"
+  mock_grep_distro "${distro}"
+  run initialize
+  assert_equal "$status" 1
+  assert_output_contains "${lines[0]}" "Detected Linux distro: ${distro}"
+  assert_output_contains "${lines[1]}" "Unsupported distro ${distro}"
 }

--- a/tests/unit/packages/utils.bats
+++ b/tests/unit/packages/utils.bats
@@ -18,30 +18,29 @@ function teardown() {
 
 @test "error function writes correct contents to stderr" {
   exp="oh nose :("
-  run error ${exp}
+  run error "${exp}"
   assert_equal "$status" 0
   assert_error_output "${output}" "${exp}"
 }
 
 @test "mac bootstrapped correctly" {
-  declare -x unix_name="Darwin"
-  initialize
+  unix_name="Darwin" initialize
+
   assert_equal $? 0
   assert_equal "${OPERATING_SYSTEM}" "${MAC_OS}"
 }
 
 @test "windows errors correctly" {
-  declare -x unix_name="MINGW"
-
   exp_err="[swellaby_dotfiles]: Unsupported OS. Are you on Windows using Git Bash or Cygwin?"
 
-  run initialize
+  unix_name="MINGW" run initialize
+
   assert_equal "$status" 1
   assert_equal "${output}" "${exp_err}"
 }
 
 @test "linux install errors correctly without identification file" {
-  rm $OS_RELEASE_TMP_FILE
+  rm "${OS_RELEASE_TMP_FILE}"
   declare -x LINUX_DISTRO_OS_IDENTIFICATION_FILE=$OS_RELEASE_TMP_FILE
   exp_err="Detected Linux OS but did not find '${OS_RELEASE_TMP_FILE}' file"
 

--- a/tests/unit/packages/utils.bats
+++ b/tests/unit/packages/utils.bats
@@ -26,6 +26,8 @@ function assert_fedora_variables() {
   assert_equal "${OPERATING_SYSTEM}" "${LINUX_OS}"
   assert_equal "${LINUX_DISTRO}" "${distro}"
   assert_equal "${LINUX_DISTRO_FAMILY}" "${FEDORA_DISTRO_FAMILY}"
+  assert_equal "${INSTALL_SUBCOMMAND}" "${FEDORA_INSTALL_SUBCOMMAND}"
+  assert_equal "${INSTALLER_SUFFIX}" "${FEDORA_INSTALLER_SUFFIX}"
 }
 
 function assert_debian_variables() {
@@ -38,6 +40,8 @@ function assert_debian_variables() {
   assert_equal "${OPERATING_SYSTEM}" "${LINUX_OS}"
   assert_equal "${LINUX_DISTRO}" "${distro}"
   assert_equal "${LINUX_DISTRO_FAMILY}" "${DEBIAN_DISTRO_FAMILY}"
+  assert_equal "${INSTALL_SUBCOMMAND}" "${DEBIAN_INSTALL_SUBCOMMAND}"
+  assert_equal "${INSTALLER_SUFFIX}" "${DEBIAN_INSTALLER_SUFFIX}"
 }
 
 @test "error function writes correct contents to stderr" {
@@ -59,6 +63,8 @@ function assert_debian_variables() {
 
   assert_equal $? 0
   assert_equal "${OPERATING_SYSTEM}" "${MAC_OS}"
+  assert_equal "${PACKAGE_MANAGER}" "${MACOS_PACKAGE_MANAGER}"
+  assert_equal "${INSTALL_SUBCOMMAND}" "${MACOS_INSTALL_SUBCOMMAND}"
 }
 
 @test "windows errors correctly" {
@@ -120,6 +126,6 @@ function assert_debian_variables() {
   mock_grep_distro "${distro}"
   run initialize
   assert_equal "$status" 1
-  assert_output_contains "${lines[0]}" "Detected Linux distro: ${distro}"
-  assert_output_contains "${lines[1]}" "Unsupported distro ${distro}"
+  assert_output_contains "${lines[0]}" "Detected Linux distro: '${distro}'"
+  assert_output_contains "${lines[1]}" "Unsupported distro: '${distro}'"
 }

--- a/tests/unit/packages/utils.bats
+++ b/tests/unit/packages/utils.bats
@@ -1,0 +1,15 @@
+#!/usr/bin/env bats
+
+load "../../../test_helper_libs/bats-support/load"
+load "../../../test_helper_libs/bats-assert/load"
+
+function setup() {
+  source ${BATS_TEST_DIRNAME}/../../../src/packages/utils.sh
+}
+
+@test "mac bootstrapped correctly" {
+  unix_name="Darwin"
+  initialize
+  assert_equal $? 0
+  assert_equal "${OPERATING_SYSTEM}" "${MAC_OS}"
+}

--- a/tests/unit/packages/utils.bats
+++ b/tests/unit/packages/utils.bats
@@ -68,12 +68,12 @@ function assert_debian_variables() {
 }
 
 @test "windows errors correctly" {
-  exp_err="[swellaby_dotfiles]: Unsupported OS. Are you on Windows using Git Bash or Cygwin?"
+  exp_err="Unsupported OS. Are you on Windows using Git Bash or Cygwin?"
 
   unix_name="MINGW" run initialize
 
   assert_equal "$status" 1
-  assert_equal "${output}" "${exp_err}"
+  assert_output_contains "${output}" "${exp_err}"
 }
 
 @test "linux install errors correctly without identification file" {

--- a/tests/unit/packages/utils/initialize.bats
+++ b/tests/unit/packages/utils/initialize.bats
@@ -6,6 +6,8 @@ load "../../../../test_helper_libs/bats-assert/load"
 # shellcheck source=tests/test_helpers.sh
 source "${BATS_TEST_DIRNAME}/../../../test_helpers.sh"
 
+readonly TEST_SUITE_PREFIX="packages::utils::initialize::"
+
 function setup() {
   # shellcheck source=src/packages/utils.sh
   source "${BATS_TEST_DIRNAME}"/../../../../src/packages/utils.sh
@@ -46,21 +48,21 @@ function assert_debian_variables() {
   assert_equal "${INSTALLER_SUFFIX}" "${DEBIAN_INSTALLER_SUFFIX}"
 }
 
-@test "error function writes correct contents to stderr" {
+@test "${TEST_SUITE_PREFIX}error function writes correct contents to stderr" {
   exp="oh nose :("
   run error "${exp}"
   assert_equal "$status" 0
   assert_output_contains "${output}" "${exp}"
 }
 
-@test "info function writes correct contents to stdout" {
+@test "${TEST_SUITE_PREFIX}info function writes correct contents to stdout" {
   exp="something or other"
   run info "${exp}"
   assert_equal "$status" 0
   assert_output_contains "${output}" "${exp}"
 }
 
-@test "mac bootstrapped correctly" {
+@test "${TEST_SUITE_PREFIX}mac bootstrapped correctly" {
   unix_name="Darwin" initialize
 
   assert_equal $? 0
@@ -72,7 +74,7 @@ function assert_debian_variables() {
   assert_equal "${INSTALL_COMMAND}" " ${MACOS_PACKAGE_MANAGER} ${MACOS_INSTALL_SUBCOMMAND} "
 }
 
-@test "windows errors correctly" {
+@test "${TEST_SUITE_PREFIX}windows errors correctly" {
   exp_err="Unsupported OS. Are you on Windows using Git Bash or Cygwin?"
 
   unix_name="MINGW" run initialize
@@ -81,7 +83,7 @@ function assert_debian_variables() {
   assert_output_contains "${output}" "${exp_err}"
 }
 
-@test "linux install errors correctly without identification file" {
+@test "${TEST_SUITE_PREFIX}linux install errors correctly without identification file" {
   rm "${OS_RELEASE_TMP_FILE}"
   exp_err="Detected Linux OS but did not find '${OS_RELEASE_TMP_FILE}' file"
 
@@ -90,42 +92,42 @@ function assert_debian_variables() {
   assert_output_contains "${output}" "${exp_err}"
 }
 
-@test "centos bootstrapped correctly" {
+@test "${TEST_SUITE_PREFIX}centos bootstrapped correctly" {
   mock_grep_distro "${CENTOS_DISTRO}"
   initialize
 
   assert_fedora_variables "${CENTOS_DISTRO}" $?
 }
 
-@test "rhel bootstrapped correctly" {
+@test "${TEST_SUITE_PREFIX}rhel bootstrapped correctly" {
   mock_grep_distro "${RHEL_DISTRO}"
   initialize
 
   assert_fedora_variables "${RHEL_DISTRO}" $?
 }
 
-@test "fedora bootstrapped correctly" {
+@test "${TEST_SUITE_PREFIX}fedora bootstrapped correctly" {
   mock_grep_distro "${FEDORA_DISTRO}"
   initialize
 
   assert_fedora_variables "${FEDORA_DISTRO}" $?
 }
 
-@test "ubuntu bootstrapped correctly" {
+@test "${TEST_SUITE_PREFIX}ubuntu bootstrapped correctly" {
   mock_grep_distro "${UBUNTU_DISTRO}"
   initialize
 
   assert_debian_variables "${UBUNTU_DISTRO}" $?
 }
 
-@test "debian bootstrapped correctly" {
+@test "${TEST_SUITE_PREFIX}debian bootstrapped correctly" {
   mock_grep_distro "${DEBIAN_DISTRO}"
   initialize
 
   assert_debian_variables "${DEBIAN_DISTRO}" $?
 }
 
-@test "unsupported distro errors correctly" {
+@test "${TEST_SUITE_PREFIX}unsupported distro errors correctly" {
   distro="super new kinda fake distro"
   mock_grep_distro "${distro}"
   run initialize
@@ -134,7 +136,7 @@ function assert_debian_variables() {
   assert_output_contains "${lines[1]}" "Unsupported distro: '${distro}'"
 }
 
-@test "linux install prefix set correctly with root" {
+@test "${TEST_SUITE_PREFIX}linux install prefix set correctly with root" {
   mock_grep_distro "${DEBIAN_DISTRO}"
   USER_ID=0 initialize
 
@@ -142,14 +144,14 @@ function assert_debian_variables() {
   assert_equal "${INSTALL_COMMAND}" " ${DEBIAN_PACKAGE_MANAGER} ${DEBIAN_INSTALL_SUBCOMMAND} ${DEBIAN_INSTALLER_SUFFIX}"
 }
 
-@test "linux install prefix set correctly without root" {
+@test "${TEST_SUITE_PREFIX}linux install prefix set correctly without root" {
   mock_grep_distro "${FEDORA_DISTRO}"
   USER_ID=1 initialize
   assert_equal "${INSTALLER_PREFIX}" "sudo"
   assert_equal "${INSTALL_COMMAND}" "sudo ${FEDORA_PACKAGE_MANAGER} ${FEDORA_INSTALL_SUBCOMMAND} ${FEDORA_INSTALLER_SUFFIX}"
 }
 
-@test "global defaults set correctly" {
+@test "${TEST_SUITE_PREFIX}global defaults set correctly" {
   assert_equal "${USER_ID}" "${UID}"
   assert_equal "${unix_name}" "$(uname)"
   assert_equal "${MAC_OS}" "macos"

--- a/tests/unit/packages/utils/initialize.bats
+++ b/tests/unit/packages/utils/initialize.bats
@@ -1,14 +1,14 @@
 #!/usr/bin/env bats
 
-load "../../../test_helper_libs/bats-support/load"
-load "../../../test_helper_libs/bats-assert/load"
+load "../../../../test_helper_libs/bats-support/load"
+load "../../../../test_helper_libs/bats-assert/load"
 
 # shellcheck source=tests/test_helpers.sh
-source "${BATS_TEST_DIRNAME}/../../test_helpers.sh"
+source "${BATS_TEST_DIRNAME}/../../../test_helpers.sh"
 
 function setup() {
   # shellcheck source=src/packages/utils.sh
-  source "${BATS_TEST_DIRNAME}"/../../../src/packages/utils.sh
+  source "${BATS_TEST_DIRNAME}"/../../../../src/packages/utils.sh
   setup_os_release_file
 }
 

--- a/tests/unit/packages/utils/install.bats
+++ b/tests/unit/packages/utils/install.bats
@@ -6,6 +6,8 @@ load "../../../../test_helper_libs/bats-assert/load"
 # shellcheck source=tests/test_helpers.sh
 source "${BATS_TEST_DIRNAME}/../../../test_helpers.sh"
 
+readonly TEST_SUITE_PREFIX="packages::utils::install::"
+
 function setup() {
   # shellcheck source=src/packages/utils.sh
   source "${BATS_TEST_DIRNAME}"/../../../../src/packages/utils.sh
@@ -19,27 +21,27 @@ function teardown() {
   teardown_os_release_file
 }
 
-@test "errors correctly on no args" {
+@test "${TEST_SUITE_PREFIX}errors correctly on no args" {
   run install
   assert_equal "${status}" 1
   assert_output_contains "${output}" "No args passed to 'install' but at a minimum a snap or package name must be provided. This is a bug!"
 }
 
-@test "errors correctly on invalid arg" {
+@test "${TEST_SUITE_PREFIX}errors correctly on invalid arg" {
   fake_arg="--real-fake"
   run install "${fake_arg}"
   assert_equal "${status}" 1
   assert_output_contains "${output}" "Invalid 'install' arg: '${fake_arg}'. This is a bug!"
 }
 
-@test "snap preference disabled by default" {
+@test "${TEST_SUITE_PREFIX}snap preference disabled by default" {
   package_name="nyancat"
   LINUX_DISTRO_FAMILY="${DEBIAN_DISTRO_FAMILY}" run install --debian-family-package-name "${package_name}"
   assert_equal "${status}" 0
   assert_mock_install_package_called_with "${output}" "-n ${package_name}"
 }
 
-@test "snap installed correctly with prefix long arg name" {
+@test "${TEST_SUITE_PREFIX}snap installed correctly with prefix long arg name" {
   snap_name="code"
   snap_prefix="--classic"
   SNAP_AVAILABLE=true run install --prefer-snap --snap-name "${snap_name}" --snap-prefix "${snap_prefix}"
@@ -47,7 +49,7 @@ function teardown() {
   assert_mock_install_snap_called_with "${lines[0]}" "-n ${snap_name} -p ${snap_prefix}"
 }
 
-@test "snap installed correctly with prefix short arg name" {
+@test "${TEST_SUITE_PREFIX}snap installed correctly with prefix short arg name" {
   snap_name="slack"
   snap_prefix="--classic"
   SNAP_AVAILABLE=true run install -pfs -s "${snap_name}" -sp "${snap_prefix}"
@@ -55,7 +57,7 @@ function teardown() {
   assert_mock_install_snap_called_with "${lines[0]}" "-n ${snap_name} -p ${snap_prefix}"
 }
 
-@test "falls back to package manager with snap preference but snap unavailable" {
+@test "${TEST_SUITE_PREFIX}falls back to package manager with snap preference but snap unavailable" {
   package_name="wget"
   LINUX_DISTRO_FAMILY="${DEBIAN_DISTRO_FAMILY}" SNAP_AVAILABLE=false run install --debian-family-package-name "${package_name}" --prefer-snap
   assert_equal "${status}" 0
@@ -63,7 +65,7 @@ function teardown() {
   assert_mock_install_package_called_with "${lines[1]}" "-n ${package_name}"
 }
 
-@test "falls back to package manager with snap preference but snap install failed" {
+@test "${TEST_SUITE_PREFIX}falls back to package manager with snap preference but snap install failed" {
   mock_install_snap 1
   package_name="docker.io"
   snap_name="firefox"
@@ -75,7 +77,7 @@ function teardown() {
   assert_mock_install_package_called_with "${lines[3]}" "-n ${package_name}"
 }
 
-@test "utilizes package prefix for fedora family" {
+@test "${TEST_SUITE_PREFIX}utilizes package prefix for fedora family" {
   package_name="foo"
   package_prefix="don't you. forget about me."
   LINUX_DISTRO_FAMILY="${FEDORA_DISTRO_FAMILY}" run install --fedora-family-package-name "${package_name}" -p "${package_prefix}"
@@ -83,7 +85,7 @@ function teardown() {
   assert_mock_install_package_called_with "${lines[0]}" "-n ${package_name} -p ${package_prefix}"
 }
 
-@test "errors correctly on fedora family when corresponding package name not provided" {
+@test "${TEST_SUITE_PREFIX}errors correctly on fedora family when corresponding package name not provided" {
   package_name="oh debian"
   exp_distro="${FEDORA_DISTRO}"
   LINUX_DISTRO_FAMILY="${FEDORA_DISTRO_FAMILY}" LINUX_DISTRO="${exp_distro}" run install -dfpn "${package_name}"
@@ -91,7 +93,7 @@ function teardown() {
   assert_output_contains "${output}" "On ${exp_distro} but package name was not provided for platform. This is likely a bug."
 }
 
-@test "utilizes package prefix for debian family" {
+@test "${TEST_SUITE_PREFIX}utilizes package prefix for debian family" {
   package_name="bar"
   package_prefix="wait, what was i supposed to do again?"
   LINUX_DISTRO_FAMILY="${DEBIAN_DISTRO_FAMILY}" run install -dfpn "${package_name}" --package-prefix "${package_prefix}"
@@ -99,7 +101,7 @@ function teardown() {
   assert_mock_install_package_called_with "${lines[0]}" "-n ${package_name} -p ${package_prefix}"
 }
 
-@test "errors correctly on debian family when corresponding package name not provided" {
+@test "${TEST_SUITE_PREFIX}errors correctly on debian family when corresponding package name not provided" {
   package_name="oh fedora"
   exp_distro="${UBUNTU_DISTRO}"
   LINUX_DISTRO_FAMILY="${DEBIAN_DISTRO_FAMILY}" LINUX_DISTRO="${exp_distro}" run install -ffpn "${package_name}"
@@ -107,14 +109,14 @@ function teardown() {
   assert_output_contains "${output}" "On ${exp_distro} but package name was not provided for platform. This is likely a bug."
 }
 
-@test "correctly installs package on mac with no prefix" {
+@test "${TEST_SUITE_PREFIX}correctly installs package on mac with no prefix" {
   package_name="shfmt"
   OPERATING_SYSTEM=${MAC_OS} run install -m "${package_name}"
   assert_equal "${status}" 0
   assert_mock_install_package_called_with "${lines[0]}" "-n ${package_name}"
 }
 
-@test "correctly installs package on mac with prefix" {
+@test "${TEST_SUITE_PREFIX}correctly installs package on mac with prefix" {
   package_name="visual-studio-code"
   prefix="--cask"
   OPERATING_SYSTEM=${MAC_OS} run install --mac-package-name "${package_name}" -mp "${prefix}"
@@ -122,7 +124,7 @@ function teardown() {
   assert_mock_install_package_called_with "${lines[0]}" "-n ${package_name} -p ${prefix}"
 }
 
-@test "errors correctly on mac when corresponding package name not provided" {
+@test "${TEST_SUITE_PREFIX}errors correctly on mac when corresponding package name not provided" {
   package_name="oh linux"
   OPERATING_SYSTEM="${MAC_OS}" run install -dfpn "${package_name}"
   assert_equal "${status}" 0

--- a/tests/unit/packages/utils/install.bats
+++ b/tests/unit/packages/utils/install.bats
@@ -11,6 +11,7 @@ function setup() {
   source "${BATS_TEST_DIRNAME}"/../../../../src/packages/utils.sh
   setup_os_release_file
   mock_install_snap
+  # shellcheck disable=SC2119
   mock_install_package
 }
 

--- a/tests/unit/packages/utils/install.bats
+++ b/tests/unit/packages/utils/install.bats
@@ -1,0 +1,59 @@
+#!/usr/bin/env bats
+
+load "../../../../test_helper_libs/bats-support/load"
+load "../../../../test_helper_libs/bats-assert/load"
+
+# shellcheck source=tests/test_helpers.sh
+source "${BATS_TEST_DIRNAME}/../../../test_helpers.sh"
+
+function setup() {
+  # shellcheck source=src/packages/utils.sh
+  source "${BATS_TEST_DIRNAME}"/../../../../src/packages/utils.sh
+  setup_os_release_file
+  mock_install_snap
+  mock_install_package
+}
+
+function teardown() {
+  teardown_os_release_file
+}
+
+@test "errors correctly on no args" {
+  run install
+  assert_equal "${status}" 1
+  assert_output_contains "${output}" "No args passed to 'install' but at a minimum a snap or package name must be provided. This is a bug!"
+}
+
+@test "errors correctly on invalid arg" {
+  fake_arg="--real-fake"
+  run install "${fake_arg}"
+  assert_equal "${status}" 1
+  assert_output_contains "${output}" "Invalid 'install' arg: '${fake_arg}'. This is a bug!"
+}
+
+@test "snap preference disabled by default" {
+  package_name="nyancat"
+  run install --package-name "${package_name}"
+  assert_equal "${status}" 0
+  assert_mock_install_package_called_with "${output}" "-n ${package_name}"
+}
+
+@test "falls back to package manager with snap preference but snap unavailable" {
+  package_name="wget"
+  SNAP_AVAILABLE=false run install --package-name "${package_name}" --prefer-snap
+  assert_equal "${status}" 0
+  assert_output_contains "${lines[0]}" "Snap install preferred but Snap not available. This is a bug!"
+  assert_mock_install_package_called_with "${lines[1]}" "-n ${package_name}"
+}
+
+@test "falls back to package manager with snap preference but snap install failed" {
+  mock_install_snap 1
+  package_name="docker.io"
+  snap_name="firefox"
+  SNAP_AVAILABLE=true run install -s "${snap_name}" -n "${package_name}" --prefer-snap
+  assert_equal "${status}" 0
+  assert_mock_install_snap_called_with "${lines[0]}" "-n ${snap_name}"
+  assert_output_contains "${lines[1]}" "Attempted but failed to install Snap: '${snap_name}'"
+  assert_output_contains "${lines[2]}" "Falling back to package manager"
+  assert_mock_install_package_called_with "${lines[3]}" "-n ${package_name}"
+}

--- a/tests/unit/packages/utils/install_package.bats
+++ b/tests/unit/packages/utils/install_package.bats
@@ -11,7 +11,7 @@ readonly MOCK_INSTALL_COMMAND="mock_package_manager"
 readonly TEST_SUITE_PREFIX="utils::install_package::"
 
 function mock_package_manager() {
-  echo "${MOCK_PACKAGE_MANAGER_PREFIX}$@"
+  echo "${MOCK_PACKAGE_MANAGER_PREFIX}$*"
 }
 
 function assert_package_manager_called_with() {

--- a/tests/unit/packages/utils/install_package.bats
+++ b/tests/unit/packages/utils/install_package.bats
@@ -8,7 +8,7 @@ source "${BATS_TEST_DIRNAME}/../../../test_helpers.sh"
 
 readonly MOCK_PACKAGE_MANAGER_PREFIX="mock_pm_install: "
 readonly MOCK_INSTALL_COMMAND="mock_package_manager"
-readonly TEST_SUITE_PREFIX="utils::install_package::"
+readonly TEST_SUITE_PREFIX="packages::utils::install_package::"
 
 function mock_package_manager() {
   echo "${MOCK_PACKAGE_MANAGER_PREFIX}$*"

--- a/tests/unit/packages/utils/install_package.bats
+++ b/tests/unit/packages/utils/install_package.bats
@@ -1,0 +1,76 @@
+#!/usr/bin/env bats
+
+load "../../../../test_helper_libs/bats-support/load"
+load "../../../../test_helper_libs/bats-assert/load"
+
+# shellcheck source=tests/test_helpers.sh
+source "${BATS_TEST_DIRNAME}/../../../test_helpers.sh"
+
+readonly MOCK_PACKAGE_MANAGER_PREFIX="mock_pm_install: "
+readonly MOCK_INSTALL_COMMAND="mock_package_manager"
+readonly TEST_SUITE_PREFIX="utils::install_package::"
+
+function mock_package_manager() {
+  echo "${MOCK_PACKAGE_MANAGER_PREFIX}$@"
+}
+
+function assert_package_manager_called_with() {
+  local exp_args="${1}"
+
+  assert_equal "${output}" "${MOCK_PACKAGE_MANAGER_PREFIX}${exp_args}"
+}
+
+function setup() {
+  # shellcheck source=src/packages/utils.sh
+  source "${BATS_TEST_DIRNAME}"/../../../../src/packages/utils.sh
+  setup_os_release_file
+  declare -f mock_package_manager
+  declare -x INSTALL_COMMAND="${MOCK_INSTALL_COMMAND}"
+}
+
+function teardown() {
+  teardown_os_release_file
+}
+
+@test "${TEST_SUITE_PREFIX}errors correctly on invalid args" {
+  invalid_arg="--what-the-what"
+  run install_package "${invalid_arg}"
+  assert_equal "${status}" 1
+  assert_output_contains "${output}" "Invalid 'install_package' arg: '${invalid_arg}'. This is a bug!"
+}
+
+@test "${TEST_SUITE_PREFIX}errors correctly on no package name" {
+  run install_package
+  assert_equal "${status}" 1
+  assert_output_contains "${output}" "No package name provided to 'install_package'. This is a bug!"
+}
+
+@test "${TEST_SUITE_PREFIX}correctly installs package with short arg name and no prefix" {
+  package_name="nyancat"
+  INSTALL_COMMAND="${MOCK_INSTALL_COMMAND}" run install_package -n "${package_name}"
+  assert_equal "${status}" 0
+  assert_package_manager_called_with "${package_name}"
+}
+
+@test "${TEST_SUITE_PREFIX}correctly installs package with long arg name and no prefix" {
+  package_name="magic-lamp"
+  INSTALL_COMMAND="${MOCK_INSTALL_COMMAND}" run install_package --package-name "${package_name}"
+  assert_equal "${status}" 0
+  assert_package_manager_called_with "${package_name}"
+}
+
+@test "${TEST_SUITE_PREFIX}correctly installs package with short arg name and prefix" {
+  package_name="cat"
+  prefix="--force"
+  INSTALL_COMMAND="${MOCK_INSTALL_COMMAND}" run install_package -n "${package_name}" -p "${prefix}"
+  assert_equal "${status}" 0
+  assert_package_manager_called_with "${prefix} ${package_name}"
+}
+
+@test "${TEST_SUITE_PREFIX}correctly installs package with long arg name and prefix" {
+  package_name="dog"
+  prefix="--woof"
+  INSTALL_COMMAND="${MOCK_INSTALL_COMMAND}" run install_package --package-name "${package_name}" --package-prefix "${prefix}"
+  assert_equal "${status}" 0
+  assert_package_manager_called_with "${prefix} ${package_name}"
+}

--- a/tests/unit/packages/utils/install_snap.bats
+++ b/tests/unit/packages/utils/install_snap.bats
@@ -1,0 +1,74 @@
+#!/usr/bin/env bats
+
+load "../../../../test_helper_libs/bats-support/load"
+load "../../../../test_helper_libs/bats-assert/load"
+
+# shellcheck source=tests/test_helpers.sh
+source "${BATS_TEST_DIRNAME}/../../../test_helpers.sh"
+
+readonly MOCK_SNAP_PREFIX="mock_snap_install: "
+readonly TEST_SUITE_PREFIX="packages::utils::install_snap::"
+
+function snap() {
+  echo "${MOCK_SNAP_PREFIX}$*"
+}
+
+function assert_snap_called_with() {
+  local exp_args="${1}"
+
+  assert_equal "${output}" "${MOCK_SNAP_PREFIX}install ${exp_args}"
+}
+
+function setup() {
+  # shellcheck source=src/packages/utils.sh
+  source "${BATS_TEST_DIRNAME}"/../../../../src/packages/utils.sh
+  setup_os_release_file
+  declare -f snap
+}
+
+function teardown() {
+  teardown_os_release_file
+}
+
+@test "${TEST_SUITE_PREFIX}errors correctly on invalid args" {
+  invalid_arg="--crackle-pop"
+  run install_snap "${invalid_arg}"
+  assert_equal "${status}" 1
+  assert_output_contains "${output}" "Invalid 'install_snap' arg: '${invalid_arg}'. This is a bug!"
+}
+
+@test "${TEST_SUITE_PREFIX}errors correctly on no package name" {
+  run install_snap
+  assert_equal "${status}" 1
+  assert_output_contains "${output}" "No snap name provided to 'install_snap'. This is a bug!"
+}
+
+@test "${TEST_SUITE_PREFIX}correctly installs snap with short arg name and no prefix" {
+  snap_name="discord"
+  run install_snap -n "${snap_name}"
+  assert_equal "${status}" 0
+  assert_snap_called_with "${snap_name}"
+}
+
+@test "${TEST_SUITE_PREFIX}correctly installs snap with long arg name and no prefix" {
+  snap_name="shfmt"
+  run install_snap --snap-name "${snap_name}"
+  assert_equal "${status}" 0
+  assert_snap_called_with "${snap_name}"
+}
+
+@test "${TEST_SUITE_PREFIX}correctly installs snap with short arg name and prefix" {
+  snap_name="code"
+  prefix="--classic"
+  run install_snap -n "${snap_name}" -p "${prefix}"
+  assert_equal "${status}" 0
+  assert_snap_called_with "${prefix} ${snap_name}"
+}
+
+@test "${TEST_SUITE_PREFIX}correctly installs snap with long arg name and prefix" {
+  snap_name="slack"
+  prefix="--classic"
+  run install_snap --snap-name "${snap_name}" --snap-prefix "${prefix}"
+  assert_equal "${status}" 0
+  assert_snap_called_with "${prefix} ${snap_name}"
+}


### PR DESCRIPTION
Add core utility functions for handling the application/packages feature bucket. These provide some common/reusable capabilities that have the multi-platform complexity encapsulated within.

@beverts312 - this is one of the first steps towards the project we discussed offline the other day for setting up and managing configuration of machines. It essentially breaks down into two core feature buckets: configuration/dotfiles which define various configurations, variables, aliases, functions, etc. to be sourced, and scripts/utils for installing the various applications, tools, etc. (along with their respective install/bootstrapping scripts).

This is the first step for that latter bucket, obviously doesn't do anything for the former. Gist of the idea is to make things as simple and succinct as possible within the scripts/libs that are used for a specific app/tool by reusing the functions/globals made available from this file.

E.g. for say installing .NET 5, it could be as simple as:
```bash
source utils.sh
install --mac-package-name "dotnet-sdk" --mac-package-prefix "--cask" --debian-family-package-name "dotnet-sdk-5.0" --fedora-family-package-name "dotnet-sdk-5.0"
```

and so on for VS Code, Slack, and whatever other tools, all without needing duplicative checks to determine OS/platform/package manager/etc.

I acknowledge the diff size showing on GitHub may be a bit eye popping at first glance, but note that ~2/3 of that is just unit tests. If you get an opportunity to review but are stretched on time, then the most important file to browse would be `utils.sh`. 

Thoughts/feedback on the overall plan are of course welcome as well