### PR TITLE
refactor: extract some common test utils for `tool_installed`

### DIFF
--- a/tests/test_helpers.sh
+++ b/tests/test_helpers.sh
@@ -11,7 +11,8 @@ readonly STD_OUT_TMP_FILE=${BATS_TMPDIR}/stdout
 readonly ERROR_MESSAGE_PREFIX="[swellaby_dotfiles]: "
 readonly MOCKED_INSTALL_SNAP_CALL_ARGS_PREFIX="mock_install_snap: "
 readonly MOCKED_INSTALL_PACKAGE_CALL_ARGS_PREFIX="mock_install_package: "
-readonly MOCKED_DEFAULT_RETURN_CODE=0
+readonly MOCKED_TOOL_INSTALLED_PREFIX="mock_tool_installed:"
+declare -ir MOCKED_DEFAULT_RETURN_CODE=0
 
 readonly SRC_DIRECTORY_PATH_FROM_ROOT="src"
 readonly APPLICATIONS_DIRECTORY_PATH_FROM_ROOT="${SRC_DIRECTORY_PATH_FROM_ROOT}/applications"
@@ -52,6 +53,22 @@ function assert_output_contains() {
 
 function assert_call_args() {
   assert_equal "${output}" "${1}"
+}
+
+function assert_tool_installed_call_args() {
+  assert_line "${MOCKED_TOOL_INSTALLED_PREFIX} ${1}"
+}
+
+function mock_tool_installed() {
+  _mocked_tool_installed_return_code=${1:-$MOCKED_DEFAULT_RETURN_CODE}
+
+  function tool_installed() {
+    echo "${MOCKED_TOOL_INSTALLED_PREFIX} $*"
+    # shellcheck disable=SC2086
+    return ${_mocked_tool_installed_return_code}
+  }
+
+  declare -f tool_installed
 }
 
 function mock_grep_distro() {

--- a/tests/unit/applications/development/nodejs.bats
+++ b/tests/unit/applications/development/nodejs.bats
@@ -23,11 +23,7 @@ function setup() {
   }
   declare -f install_curl
 
-  function tool_installed() {
-    echo "${TOOL_INSTALLED_CALL_ARGS_PREFIX} $*"
-    return 0
-  }
-  declare -f tool_installed
+  mock_tool_installed
 
   function bash() {
     echo "${BASH_CALL_ARGS_PREFIX}"
@@ -53,19 +49,12 @@ function assert_install_curl_called() {
   assert_line "${INSTALL_CURL_CALL_ARGS_PREFIX}"
 }
 
-function assert_tool_installed_call_args() {
-  assert_line "${TOOL_INSTALLED_CALL_ARGS_PREFIX} ${1}"
-}
-
 function assert_bash_call_args() {
   assert_line "${BASH_CALL_ARGS_PREFIX}"
 }
 
 @test "${TEST_SUITE_PREFIX}installs curl if not available" {
-  function tool_installed() {
-    echo "${TOOL_INSTALLED_CALL_ARGS_PREFIX} ${1}"
-    return 1
-  }
+  mock_tool_installed 1
   run install_nodejs
   assert_success
   assert_tool_installed_call_args "curl"

--- a/tests/unit/applications/development/nodejs.bats
+++ b/tests/unit/applications/development/nodejs.bats
@@ -7,7 +7,6 @@ source "${DEVELOPMENT_DIRECTORY}/nodejs/nodejs.sh"
 
 readonly TEST_SUITE_PREFIX="${APPLICATIONS_DEVELOPMENT_SUITE_PREFIX}::nodejs::install_nodejs::"
 readonly INSTALL_CURL_CALL_ARGS_PREFIX="mock_install_curl:"
-readonly TOOL_INSTALLED_CALL_ARGS_PREFIX="mock_tool_installed:"
 readonly BASH_CALL_ARGS_PREFIX="mock_bash:"
 readonly SOURCE_CALL_ARGS_PREFIX="mock_source:"
 readonly NVM_CALL_ARGS_PREFIX="mock_nvm:"

--- a/tests/unit/applications/development/rust.bats
+++ b/tests/unit/applications/development/rust.bats
@@ -21,11 +21,7 @@ function setup() {
   }
   declare -f install_curl
 
-  function tool_installed() {
-    echo "${TOOL_INSTALLED_CALL_ARGS_PREFIX} $*"
-    return 0
-  }
-  declare -f tool_installed
+  mock_tool_installed
 
   function sh() {
     echo "${SH_CALL_ARGS_PREFIX} $*"
@@ -46,19 +42,12 @@ function assert_install_curl_called() {
   assert_line "${INSTALL_CURL_CALL_ARGS_PREFIX}"
 }
 
-function assert_tool_installed_call_args() {
-  assert_line "${TOOL_INSTALLED_CALL_ARGS_PREFIX} ${1}"
-}
-
 function assert_sh_call_args() {
   assert_line "${SH_CALL_ARGS_PREFIX} ${1}"
 }
 
 @test "${TEST_SUITE_PREFIX}installs curl if not available" {
-  function tool_installed() {
-    echo "${TOOL_INSTALLED_CALL_ARGS_PREFIX} ${1}"
-    return 1
-  }
+  mock_tool_installed 1
   run install_rust
   assert_success
   assert_tool_installed_call_args "curl"

--- a/tests/unit/applications/development/rust.bats
+++ b/tests/unit/applications/development/rust.bats
@@ -7,7 +7,6 @@ source "${DEVELOPMENT_DIRECTORY}/rust/rust.sh"
 
 readonly TEST_SUITE_PREFIX="${APPLICATIONS_DEVELOPMENT_SUITE_PREFIX}::rust::install_rust::"
 readonly INSTALL_CURL_CALL_ARGS_PREFIX="mock_install_curl:"
-readonly TOOL_INSTALLED_CALL_ARGS_PREFIX="mock_tool_installed:"
 readonly SH_CALL_ARGS_PREFIX="mock_sh:"
 
 function setup() {

--- a/tests/unit/applications/development/vscode.bats
+++ b/tests/unit/applications/development/vscode.bats
@@ -42,7 +42,6 @@ function setup() {
   mock_info_prefix="mock_info:"
   mock_code_prefix="mock_code:"
 
-  mock_tool_installed
   function info() {
     echo "${mock_info_prefix} $*"
   }

--- a/tests/unit/applications/development/vscode.bats
+++ b/tests/unit/applications/development/vscode.bats
@@ -7,6 +7,10 @@ source "${DEVELOPMENT_DIRECTORY}/vscode/vscode.sh"
 
 readonly TEST_SUITE_PREFIX="${APPLICATIONS_DEVELOPMENT_SUITE_PREFIX}::vscode::"
 
+function setup() {
+  mock_tool_installed
+}
+
 @test "${TEST_SUITE_PREFIX}install_vscode::uses correct args" {
   function install() {
     echo "$*"
@@ -19,13 +23,9 @@ readonly TEST_SUITE_PREFIX="${APPLICATIONS_DEVELOPMENT_SUITE_PREFIX}::vscode::"
 
 @test "${TEST_SUITE_PREFIX}install_vscode_extension::returns 1 when code not on path" {
   extension="swellaby.common-pack"
-  mock_tool_installed_prefix="mock_tool_installed:"
   mock_error_prefix="mock_error:"
 
-  function tool_installed() {
-    echo "${mock_tool_installed_prefix} $*"
-    return 7
-  }
+  mock_tool_installed 7
   function error() {
     echo "${mock_error_prefix} $*"
   }
@@ -33,20 +33,16 @@ readonly TEST_SUITE_PREFIX="${APPLICATIONS_DEVELOPMENT_SUITE_PREFIX}::vscode::"
   run install_vscode_extension "${extension}"
 
   assert_equal "$status" 1
-  assert_equal "${lines[0]}" "${mock_tool_installed_prefix} code"
+  assert_tool_installed_call_args "code"
   assert_equal "${lines[1]}" "${mock_error_prefix} Attempted to install VS Code extension '${extension}' but 'code' not on PATH"
 }
 
 @test "${TEST_SUITE_PREFIX}install_vscode_extension::installs extension when code on path" {
   extension="swellaby.rust-pack"
-  mock_tool_installed_prefix="mock_tool_installed:"
   mock_info_prefix="mock_info:"
   mock_code_prefix="mock_code:"
 
-  function tool_installed() {
-    echo "${mock_tool_installed_prefix} $*"
-    return 0
-  }
+  mock_tool_installed
   function info() {
     echo "${mock_info_prefix} $*"
   }
@@ -57,7 +53,7 @@ readonly TEST_SUITE_PREFIX="${APPLICATIONS_DEVELOPMENT_SUITE_PREFIX}::vscode::"
   run install_vscode_extension "${extension}"
 
   assert_equal "$status" 0
-  assert_equal "${lines[0]}" "${mock_tool_installed_prefix} code"
+  assert_tool_installed_call_args "code"
   assert_equal "${lines[1]}" "${mock_info_prefix} Installing VS Code extension: '${extension}'"
   assert_equal "${lines[2]}" "${mock_code_prefix} --install-extension ${extension} --force"
 }

--- a/tests/unit/utils/check_snapd_availability.bats
+++ b/tests/unit/utils/check_snapd_availability.bats
@@ -16,9 +16,7 @@ function teardown() {
 }
 
 @test "${TEST_SUITE_PREFIX}sets global correctly" {
-  function tool_installed() {
-    return 1
-  }
+  mock_tool_installed 1
 
   set +e
   check_snapd_availability
@@ -31,12 +29,9 @@ function teardown() {
 
 @test "${TEST_SUITE_PREFIX}uses correct tool name" {
   local prefix="mocked check_snapd_availability: "
-  function tool_installed() {
-    echo "${prefix}$*"
-    return 0
-  }
+  mock_tool_installed
 
   run check_snapd_availability
   assert_equal "${status}" 0
-  assert_equal "${output}" "${prefix}snap"
+  assert_tool_installed_call_args "snap"
 }

--- a/tests/unit/utils/initialize.bats
+++ b/tests/unit/utils/initialize.bats
@@ -6,13 +6,14 @@ source "${BATS_TEST_DIRNAME}/common.sh"
 readonly TEST_SUITE_PREFIX=${BASE_TEST_SUITE_PREFIX}initialize::
 
 function setup() {
-
   source "${UTILS_SOURCE_PATH}"
   setup_os_release_file
 
   function check_snapd_availability() {
     return 0
   }
+
+  declare -f check_snapd_availability
 }
 
 function teardown() {


### PR DESCRIPTION
Although I did put some forethought and reusable structures in place for the tests before diving in, we've still ended up in a place for there's some duplication across the difference test files (which was honestly an inevitably).

This is the first of likely several passes to eliminate those duplicative sections by extracting the commonalities into a single, reusable place